### PR TITLE
Add safe dereference helper

### DIFF
--- a/z.go
+++ b/z.go
@@ -23,7 +23,16 @@ func MustBe[T any](t T, err error) T {
 	return t
 }
 
-// P returns a pointer to t.
-func P[T any](t T) *T {
-	return &t
+// P returns a pointer to v.
+func P[T any](v T) *T {
+	return &v
+}
+
+// D returns the dereferenced value of p.
+// If p is nil, the zero value of T is returned instead.
+func D[T any](p *T) (v T) {
+	if p != nil {
+		v = *p
+	}
+	return
 }


### PR DESCRIPTION
(Let the bike-shedding begin!)

Add `z.D` to safely dereference pointers.