### PR TITLE
Give exports human readable names

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ First off, it's a much better name than 'y'.
 
 Besides that, the choice in name is supported by a few rules-of-thumb:
 
-- A smaller package name is more ergonomic (`z.P("foo")` vs. `utils.P("foo")`)
+- A smaller package name is more ergonomic (`z.Pointer("foo")` vs. `utils.Pointer("foo")`)
 - The last letter of the alphabet is _probably definitely_ less likely to be shadowed by dependents 
 - It's memorable (and fun to say out loud while typing!)
 

--- a/z.go
+++ b/z.go
@@ -23,14 +23,14 @@ func MustBe[T any](t T, err error) T {
 	return t
 }
 
-// P returns a pointer to v.
-func P[T any](v T) *T {
+// Pointer returns a pointer to v.
+func Pointer[T any](v T) *T {
 	return &v
 }
 
-// D returns the dereferenced value of p.
+// Dereference returns the dereferenced value of p.
 // If p is nil, the zero value of T is returned instead.
-func D[T any](p *T) (v T) {
+func Dereference[T any](p *T) (v T) {
 	if p != nil {
 		v = *p
 	}


### PR DESCRIPTION
`z.P` and `z.D` aren't comprehensible names. Rename them to `z.Pointer` and `z.Dereference` respectively.

